### PR TITLE
Get started vignette

### DIFF
--- a/vignettes/teal-logger.Rmd
+++ b/vignettes/teal-logger.Rmd
@@ -185,7 +185,7 @@ logger::log_appender(logger::appender_stderr, namespace = "teal")
 ```
 
 ## Logging in other `teal.X` packages
-The other `teal.X` packages, like `teal.data`, use `teal.logger::register_logger` to register loggers in their namespace. Each package registers a logger in the namespace equal to the package name. E.g. `teal.data` registers a logger in `teal.data` namespace. A package instantiates its logger during the package loading, the same as `teal`, using `teal`'s default logging settings subject to the same modifications as `teal`'s logger.
+The other `teal.X` packages, like `teal.data`, use `teal.logger::register_logger` to register loggers in their namespace. Each package registers a logger in the namespace equal to the package name. E.g. `teal.data` registers a logger in `teal.data` namespace. A package instantiates its logger during the package loading and using the default logging settings subject to the modifications described in the sections above.
 
 ## Example of usage
 A minimal working example of logging using `teal`'s logging setup. By default `TEAL.LOG.LEVEL = "INFO"` which means that logs of level above `level = 400` won't be passed to the `stdout`.


### PR DESCRIPTION
part of https://github.com/insightsengineering/coredev-tasks/issues/155

- Updated the vignette to have `Get started` in the header.
- Missing comma added.

Reproduce the vignette with:
```
usethis::use_pkgdown()
pkgdown::build_site()
```