### PR TITLE
release 0.1.2 [skip vbump] [skip spelling]

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: teal.logger
 Title: Logging Setup for the `teal` Family of Packages
-Version: 0.1.1.9013
+Version: 0.1.2
 Date: 2023-08-31
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.logger 0.1.1.9013
+# teal.logger 0.1.2
 
 * Updated usage and installation instructions in `README`.
 * Updated phrasing of the `Getting Started` vignette.


### PR DESCRIPTION
Release v0.1.2

Related with https://github.com/insightsengineering/teal.logger/issues/51
