### PR TITLE
Missing URLs on DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,9 @@ VignetteBuilder:
     knitr
 RdMacros:
     lifecycle
+URL: https://insightsengineering.github.io/teal.logger/,
+    https://github.com/insightsengineering/teal.logger/
+BugReports: https://github.com/insightsengineering/teal.logger/issues
 Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 Language: en-US

--- a/man/teal.logger-package.Rd
+++ b/man/teal.logger-package.Rd
@@ -8,6 +8,15 @@
 \description{
 Logging Setup for the \code{teal} Family of Packages.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://insightsengineering.github.io/teal.logger/}
+  \item \url{https://github.com/insightsengineering/teal.logger/}
+  \item Report bugs at \url{https://github.com/insightsengineering/teal.logger/issues}
+}
+
+}
 \author{
 \strong{Maintainer}: Dawid Kaledkowski \email{dawid.kaledkowski@roche.com}
 


### PR DESCRIPTION
Related to #51

Closes #62

![image](https://github.com/insightsengineering/teal.logger/assets/211358/72e1be80-4fb4-4bf5-b444-e495e34ed694)
