### PR TITLE
430 use `expect_no_error` in tests instead of `expect_error(, NA)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     rmarkdown (>= 2.19),
-    testthat (>= 3.0.4)
+    testthat (>= 3.1.5)
 VignetteBuilder:
     knitr
 RdMacros:
@@ -39,4 +39,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/tests/testthat/test-register_logger.R
+++ b/tests/testthat/test-register_logger.R
@@ -66,7 +66,8 @@ testthat::test_that(
   paste(
     "register_logger",
     "does not throw if passed NULL to arguments, options are not set and the system variables are set to valid value"
-  ), {
+  ),
+  {
     withr::local_envvar(.new = list(TEAL.LOG_LAYOUT = "{msg}", TEAL.LOG_LEVEL = "INFO"))
     withr::local_options(.new = list(teal.log_layout = NULL, teal.log_level = NULL))
     testthat::expect_no_error(register_logger(namespace = "test", layout = NULL, level = NULL))

--- a/tests/testthat/test-register_logger.R
+++ b/tests/testthat/test-register_logger.R
@@ -1,7 +1,7 @@
 testthat::test_that("register_logger accepts a scalar character", {
   withr::with_options(
     new = list(teal.log_layout = NULL),
-    code = testthat::expect_error(register_logger(namespace = "test"), NA)
+    code = testthat::expect_no_error(register_logger(namespace = "test"))
   )
 })
 
@@ -39,35 +39,40 @@ testthat::test_that("An additional logging namespace is created after register_l
 testthat::test_that("register_logger does not throw if passed a correct logger layout", {
   withr::with_options(
     new = list(teal.log_level = logger::INFO),
-    code = testthat::expect_error(register_logger(namespace = "test", layout = "{msg}"), NA)
+    code = testthat::expect_no_error(register_logger(namespace = "test", layout = "{msg}"))
   )
 })
 
 testthat::test_that("register_logger does not throw if passed a correct logger level", {
   withr::with_options(
     new = list(teal.log_layout = "{msg}"),
-    code = testthat::expect_error(register_logger(namespace = "test", level = logger::INFO), NA)
+    code = testthat::expect_no_error(register_logger(namespace = "test", level = logger::INFO))
   )
 })
 
-testthat::test_that("register_logger does not throw if passed NULL to either log_layout or log_level
-  and valid options are set", {
-  withr::with_options(
-    new = list(teal.log_layout = "{msg}", teal.log_level = logger::INFO),
-    code = testthat::expect_error(
-      register_logger(namespace = "test", level = NULL, layout = NULL),
-      NA
+testthat::test_that(
+  "register_logger does not throw if passed NULL to either log_layout or log_level and valid options are set",
+  {
+    withr::with_options(
+      new = list(teal.log_layout = "{msg}", teal.log_level = logger::INFO),
+      code = testthat::expect_no_error(
+        register_logger(namespace = "test", level = NULL, layout = NULL)
+      )
     )
-  )
-})
+  }
+)
 
-testthat::test_that("register_logger does not throw if passed NULL to arguments, options are not set and
-  the system variables are set to valid value", {
-  withr::local_envvar(.new = list(TEAL.LOG_LAYOUT = "{msg}", TEAL.LOG_LEVEL = "INFO"))
-  withr::local_options(.new = list(teal.log_layout = NULL, teal.log_level = NULL))
-  testthat::expect_error(register_logger(namespace = "test", layout = NULL, level = NULL), NA)
-})
+testthat::test_that(
+  paste(
+    "register_logger",
+    "does not throw if passed NULL to arguments, options are not set and the system variables are set to valid value"
+  ), {
+    withr::local_envvar(.new = list(TEAL.LOG_LAYOUT = "{msg}", TEAL.LOG_LEVEL = "INFO"))
+    withr::local_options(.new = list(teal.log_layout = NULL, teal.log_level = NULL))
+    testthat::expect_no_error(register_logger(namespace = "test", layout = NULL, level = NULL))
+  }
+)
 
 testthat::test_that("log_system_info does not throw an error", {
-  testthat::expect_error(log_system_info(), NA)
+  testthat::expect_no_error(log_system_info())
 })


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/430