### PR TITLE
vbump testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     rmarkdown (>= 2.19),
-    testthat (>= 3.1.5)
+    testthat (>= 3.1.7)
 VignetteBuilder:
     knitr
 RdMacros:


### PR DESCRIPTION
`testthat::with_mocked_bindings` was introduced starting from `testthat@3.1.7`

This fixes verdepcheck pipelines that are currently failing: https://github.com/insightsengineering/teal.logger/actions/runs/8406661087/job/23020772844