### PR TITLE
add setup-r-dependencies

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,6 +40,8 @@ jobs:
         checking top-level files .* NOTE
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
+      deps-installation-method: setup-r-dependencies
+
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -60,6 +62,8 @@ jobs:
         checking Rd .usage sections .* NOTE
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
+      deps-installation-method: setup-r-dependencies
+
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -68,6 +72,8 @@ jobs:
     with:
       additional-env-vars: |
         NOT_CRAN=true
+      deps-installation-method: setup-r-dependencies
+
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -79,6 +85,7 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       auto-update: true
+      deps-installation-method: setup-r-dependencies
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,3 +42,4 @@ jobs:
     with:
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran
+      deps-installation-method: setup-r-dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,15 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       default-landing-page: latest-tag
+      deps-installation-method: setup-r-dependencies
   validation:
     name: R Package Validation report 📃
     needs: release
     uses: insightsengineering/r.pkg.template/.github/workflows/validation.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+    with:
+      deps-installation-method: setup-r-dependencies
   release:
     name: Create release 🎉
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
@@ -46,6 +49,7 @@ jobs:
         checking top-level files .* NOTE
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
+      deps-installation-method: setup-r-dependencies
   coverage:
     name: Coverage 📔
     needs: [release, docs]
@@ -55,6 +59,7 @@ jobs:
     with:
       additional-env-vars: |
         NOT_CRAN=true
+      deps-installation-method: setup-r-dependencies
   wasm:
     name: Build WASM packages 🧑‍🏭
     needs: release


### PR DESCRIPTION
Related to https://github.com/insightsengineering/nestdevs-tasks/issues/65
Switch to setup-r-dependencies.

A straightforward update as we don't need `lookup-refs`.