### PR TITLE
fix logger error `All unnamed arguments must be length 1`.

### DIFF
--- a/R/register_handlers.R
+++ b/R/register_handlers.R
@@ -129,7 +129,7 @@ parse_logger_message <- function(m) {
   if (type %in% c("error", "warning") && !is.null(m$call)) {
     msg <- sprintf("In %s: %s", sQuote(paste0(format(m$call), collapse = "")), msg)
   }
-  return(msg)
+  return(paste(msg, collapse = "\n"))
 }
 
 register_handlers_possible <- function() {

--- a/tests/testthat/test-register_handlers.R
+++ b/tests/testthat/test-register_handlers.R
@@ -1,12 +1,18 @@
 testthat::test_that("parse_logger_message correctly works on condition object", {
-  testthat::expect_identical(parse_logger_message(simpleMessage("foo")), "foo")
-  testthat::expect_identical(parse_logger_message(simpleWarning("foo")), "foo")
-  testthat::expect_identical(parse_logger_message(simpleError("foo")), "foo")
+  testthat::expect_identical(parse_logger_message(simpleMessage(message = "foo")), "foo")
+  testthat::expect_identical(parse_logger_message(simpleWarning(message = "foo")), "foo")
+  testthat::expect_identical(parse_logger_message(simpleError(message = "foo")), "foo")
+})
+
+testthat::test_that("parse_logger_message concatenates n-element message", {
+  testthat::expect_identical(parse_logger_message(simpleMessage(message = c("foo1", "foo2"))), "foo1\nfoo2")
+  testthat::expect_identical(parse_logger_message(simpleWarning(message = c("foo1", "foo2"))), "foo1\nfoo2")
+  testthat::expect_identical(parse_logger_message(simpleError(message = c("foo1", "foo2"))), "foo1\nfoo2")
 })
 
 testthat::test_that("parse_logger_message includes call on warnings and errors", {
-  testthat::expect_match(parse_logger_message(simpleWarning("foo", "bar")), "In .bar.: foo")
-  testthat::expect_match(parse_logger_message(simpleError("foo", "bar")), "In .bar.: foo")
+  testthat::expect_match(parse_logger_message(simpleWarning(message = "foo", call = "bar")), "In .bar.: foo")
+  testthat::expect_match(parse_logger_message(simpleError(message = "foo", call = "bar")), "In .bar.: foo")
 })
 
 testthat::test_that("parse_logger_message throws if not supported class of argument", {


### PR DESCRIPTION
`glue` fails when receives a vector of length > 1. Message generate with warning could have n-elements and `parse_logger_message` would return a vector instead of a single character.

Example

```r
teal.logger::register_logger("teal.code")
teal.logger::register_handlers("teal.code")
teal.code::qenv() |>
  within(a <- 1) |>
  teal.code::get_var("a")
  
# Error in h(simpleError(msg, call)) : 
#   `glue` failed in `formatter_glue` on:
#
#  Named chr [1:2] "`get_var()` was deprecated in teal.code 0.5.1." "Please use `base::get()` instead."
#  - attr(*, "names")= chr [1:2] "" "i"
#
# Raw error message:
#
# All unnamed arguments must be length 1
#
# Please consider using another `log_formatter` or `skip_formatter` on strings with curly braces.  
  
```