### PR TITLE
fix formatting in calling handlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # teal.logger 0.3.1.9000
 
-* Fixed a `glue` formatting issues when capturing errors, warnings or messages. #101 
+* Fixed a `glue` formatting issues when capturing errors, warnings or messages (#101).  
 
 # teal.logger 0.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # teal.logger 0.3.1.9000
 
+* Fixed a `glue` formatting issues when capturing errors, warnings or messages. #101 
+
 # teal.logger 0.3.1
 
 * Enhance `log_shiny_input_changes` to support log levels provided in lowercase or numeric values.

--- a/R/register_handlers.R
+++ b/R/register_handlers.R
@@ -87,7 +87,7 @@ register_handler_type <- function(
         msg <- parse_logger_message(m)
 
         log_namespace <- registered_handlers_namespaces[[pkg_sys_fun_i]]
-        logger_fun(msg, namespace = log_namespace)
+        logger_fun(logger::skip_formatter(msg), namespace = log_namespace)
 
         # muffle restart
         if (isTRUE(as.logical(get_val("TEAL.LOG_MUFFLE", "teal.log_muffle", TRUE)))) {


### PR DESCRIPTION
Closes #101 

```r
library(teal.logger)
fun <- function(arr, permutation.of = c("a", "b")) {
  checkmate::assert_names(names(arr), permutation.of = permutation.of)
}
environment(fun) <- environment(register_handlers)

register_handlers("teal.logger")
fun(list(b = 1, c = 2))

# [ERROR] 2025-02-06 09:29:40.8142 pid:94269 token:[] teal.logger In ‘fun(list(b = 1, c = 2))’: Assertion on 'names(arr)' failed: Names must be a permutation of set {'a','b'}, but has extra elements {'c'}.
# Error in fun(list(b = 1, c = 2)) : 
#   Assertion on 'names(arr)' failed: Names must be a permutation of set {'a','b'}, but has extra elements {'c'}.
```
