### PR TITLE
Correct version number

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: teal.logger
 Title: Logging Setup for the 'teal' Family of Packages
-Version: 0.4.2.9000
+Version: 0.4.1.9002
 Date: 2026-02-06
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: teal.logger
 Title: Logging Setup for the 'teal' Family of Packages
-Version: 0.4.1.9002
+Version: 0.4.1.9003
 Date: 2026-02-06
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.logger 0.4.2.9000
+# teal.logger 0.4.1.9003
 * Fix in vignette
 
 # teal.logger 0.4.1.9002

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # teal.logger 0.4.1.9003
 * Fix in vignette
 
-# teal.logger 0.4.1.9002
 
 # teal.logger 0.4.1
 


### PR DESCRIPTION
In the previous [merged PR](https://github.com/insightsengineering/teal.logger/pull/122) the version number was wrongly manually. Increased. This will recover the previous version with correct numbering to be increased by the bot.